### PR TITLE
Renommage label Vent et Neige

### DIFF
--- a/indice_pollution/history/models/vigilance_meteo.py
+++ b/indice_pollution/history/models/vigilance_meteo.py
@@ -39,11 +39,11 @@ class VigilanceMeteo(db.Model):
     }
 
     phenomenes = {
-        1: 'Vent',
+        1: 'Vent violent',
         2: 'Pluie-Inondation',
         3: 'Orages',
         4: 'Crues',
-        5: 'Neige',
+        5: 'Neige-verglas',
         6: 'Canicule',
         7: 'Grand Froid',
         8: 'Avalanches',


### PR DESCRIPTION
On reprend strictement les dénominations des phénomènes employés par Météo France au lieu de ceux de leur documentation :
"Neige-verglas" https://vigilance.meteofrance.fr/fr/neige-verglas
"Vent violent" https://vigilance.meteofrance.fr/fr/vent-violent

Lié à https://github.com/betagouv/recosante/issues/167