### PR TITLE
Fix conflits d’insertions pour les épisodes de pollution

### DIFF
--- a/indice_pollution/history/models/episode_pollution.py
+++ b/indice_pollution/history/models/episode_pollution.py
@@ -10,11 +10,11 @@ from sqlalchemy import  Date, text
 class EpisodePollution(db.Model):
     __table_args__ = {"schema": "indice_schema"}
 
-    zone_id: int = db.Column(db.Integer, db.ForeignKey('indice_schema.zone.id'), primary_key=True)
+    zone_id: int = db.Column(db.Integer, db.ForeignKey('indice_schema.zone.id'), primary_key=True, nullable=False)
     zone = relationship("indice_pollution.history.models.zone.Zone")
-    date_ech: datetime = db.Column(db.DateTime, primary_key=True)
-    date_dif: datetime = db.Column(db.DateTime, primary_key=True)
-    code_pol: int = db.Column(db.Integer, primary_key=True)
+    date_ech: datetime = db.Column(db.DateTime, primary_key=True, nullable=False)
+    date_dif: datetime = db.Column(db.DateTime, primary_key=True, nullable=False)
+    code_pol: int = db.Column(db.Integer, primary_key=True, nullable=False)
     etat: str = db.Column(db.String)
     com_court: str = db.Column(db.String)
     com_long: str = db.Column(db.String)

--- a/indice_pollution/regions/__init__.py
+++ b/indice_pollution/regions/__init__.py
@@ -359,7 +359,7 @@ class ForecastMixin(ServiceMixin):
             "o3" :properties.get('code_o3'),
             "pm10" :properties.get('code_pm10'),
             "pm25" :properties.get('code_pm25'),
-            "valeur" :properties.get('code_qual') or properties['valeur']
+            "valeur" :properties.get('code_qual',properties.get('valeur'))
         }
 
 class EpisodeMixin(ServiceMixin):

--- a/indice_pollution/regions/__init__.py
+++ b/indice_pollution/regions/__init__.py
@@ -167,7 +167,16 @@ class ServiceMixin(object):
                         [v['zone_code'] for v in values]
                     )
                 )
-            ).on_conflict_do_nothing()
+            )
+            primary_cols = self.DB_OBJECT.__table__.primary_key
+            ins = ins.on_conflict_do_update(
+                index_elements=primary_cols,
+                set_={
+                    cname: getattr(ins.excluded, cname)
+                    for cname in self.DB_OBJECT.__table__.c.keys()
+                    if cname not in [c.name for c in primary_cols]
+                }
+            )
             db.session.execute(ins)
         db.session.commit()
 


### PR DESCRIPTION
L’Ile de France ne met pas à jour la date de diffusion lorsqu’ils mettent à jour le même jour, ce qui impliquait qu’on ne mettait pas à jour la base de données.