### PR TITLE
Découpage des tâches celery périodiques

### DIFF
--- a/indice_pollution/history/models/raep.py
+++ b/indice_pollution/history/models/raep.py
@@ -46,6 +46,7 @@ class RAEP(db.Model):
     )
     liste_allergenes = ["cypres", "noisetier", "aulne", "peuplier", "saule", "frene", "charme", "bouleau", "platane", "chene", "olivier", "tilleul", "chataignier", "rumex", "graminees", "plantain", "urticacees", "armoises", "ambroisies"]
 
+
     @classmethod
     def save_all(cls):
         if not os.getenv('ALLERGIES_URL'):

--- a/indice_pollution/regions/Auvergne-Rhône-Alpes.py
+++ b/indice_pollution/regions/Auvergne-Rhône-Alpes.py
@@ -13,7 +13,8 @@ class Forecast(Service, ForecastMixin):
     get_only_from_scraping = True
     url = 'https://services3.arcgis.com/o7Q3o5SkiSeZD5LK/arcgis/rest/services/Indice_ATMO/FeatureServer/0/query'
 
-    def get_from_scraping(self, previous_results, date_, insee):
+    @classmethod
+    def get_from_scraping(cls, previous_results, date_, insee):
         api_key = os.getenv('AURA_API_KEY')
         if not api_key:
             return []
@@ -25,7 +26,7 @@ class Forecast(Service, ForecastMixin):
             current_app.logger.error(e)
             return []
         return [
-            self.getter({
+            cls.getter({
                 "date": indice['date_echeance'],
                 "lib_qual": indice['qualificatif']
             })

--- a/indice_pollution/regions/Bourgogne-Franche-Comté.py
+++ b/indice_pollution/regions/Bourgogne-Franche-Comté.py
@@ -25,8 +25,8 @@ class Forecast(Service, ForecastMixin):
             'CQL_FILTER': f"date_ech >= '{date_}T00:00:00Z' AND code_zone={insee}"
         }
 
-    @property
-    def params_fetch_all(self):
+    @classmethod
+    def params_fetch_all(cls):
         return {
             'service': 'WFS',
             'version': '2.0.0',
@@ -56,11 +56,12 @@ class Episode(Service, EpisodeMixin):
             'geometryType': 'esriGeometryPoint',
         }
 
-    def getter(self, attributes):
+    @classmethod
+    def getter(cls, attributes):
         return super().getter({'code_pol': attributes['id_poll_ue'], **attributes})
 
-    @property
-    def params_fetch_all(self):
+    @classmethod
+    def params_fetch_all(cls):
         return {
             'service': 'WFS',
             'version': '2.0.0',

--- a/indice_pollution/regions/Bretagne.py
+++ b/indice_pollution/regions/Bretagne.py
@@ -221,15 +221,13 @@ class Forecast(Service, ForecastMixin):
             'CQL_FILTER': f"code_zone = {epci} AND date_ech>='{date_}'"
         }
 
-    @property
-    def params_fetch_all(self):
-        return {
-                'service': 'WFS',
-                'version': '1.0.0',
-                'request': 'GetFeature',
-                'typeName': 'ind_bretagne:ind_bretagne_j1',
-                'outputFormat': 'application/json',
-            }
+    params_fetch_all= {
+        'service': 'WFS',
+        'version': '1.0.0',
+        'request': 'GetFeature',
+        'typeName': 'ind_bretagne:ind_bretagne_j1',
+        'outputFormat': 'application/json',
+    }
 
 class Episode(Service, EpisodeMixin):
     url = 'https://data.airbreizh.asso.fr/geoserver/alrt3j_bretagne/ows'
@@ -251,12 +249,10 @@ class Episode(Service, EpisodeMixin):
             'Filter': f'<Filter>{filter_zone}</Filter>',
         }
 
-    @property
-    def params_fetch_all(self):
-        return {
-                'service': 'WFS',
-                'version': '1.0.0',
-                'request': 'GetFeature',
-                'typeName': 'alrt3j_bretagne',
-                'outputFormat': 'application/json',
-            }
+    params_fetch_all = {
+        'service': 'WFS',
+        'version': '1.0.0',
+        'request': 'GetFeature',
+        'typeName': 'alrt3j_bretagne',
+        'outputFormat': 'application/json',
+    }

--- a/indice_pollution/regions/Centre-Val de Loire.py
+++ b/indice_pollution/regions/Centre-Val de Loire.py
@@ -22,7 +22,8 @@ class Forecast(Service, ForecastMixin):
             'outSR': '4326'
         }
 
-    def getter(self, attributes):
+    @classmethod
+    def getter(cls, attributes):
         return super().getter(
             {
                 'couleur': attributes.get('coul_qual'),
@@ -30,8 +31,9 @@ class Forecast(Service, ForecastMixin):
             }
         )
 
-    def get_from_scraping(self, previous_results, date_, insee):
-        r = requests.get(f'http://www.ligair.fr/commune/{self.get_nom_ville(insee)}')
+    @classmethod
+    def get_from_scraping(cls, previous_results, date_, insee):
+        r = requests.get(f'http://www.ligair.fr/commune/{cls.get_nom_ville(insee)}')
         soup = BeautifulSoup(r.text, "html.parser")
         indices = soup.find_all('div', class_='atmo-index-legend')
         legend = indices[0]
@@ -41,7 +43,7 @@ class Forecast(Service, ForecastMixin):
         today_text = next(filter(lambda v: "Aujourd'hui" in v.find_next('strong').text, labels)).text
         indice = today_text[len("Aujourd'hui : "):].lower()
         return previous_results + [
-            self.getter({
+            cls.getter({
                 "date": str(date_), 
                 "indice": indice,
             })

--- a/indice_pollution/regions/Normandie.py
+++ b/indice_pollution/regions/Normandie.py
@@ -49,7 +49,8 @@ class Forecast(Service, ForecastMixin):
             return None
         return r
 
-    def get_one_attempt_fetch_all(self, url, params):
+    @classmethod
+    def get_one_attempt_fetch_all(cls, url, params):
         params = {'project': 'flux_indice_atmo_normandie', 'repository': 'dindice'}
         data = {
             'OUTPUTFORMAT': 'GeoJSON',
@@ -62,11 +63,11 @@ class Forecast(Service, ForecastMixin):
         try:
             r = requests.post(url, params=params, data=data)
         except requests.exceptions.ConnectionError as e:
-            logging.error(f'Impossible de se connecter à {self.url}')
+            logging.error(f'Impossible de se connecter à {cls.url}')
             logging.error(e)
             return None
         except requests.exceptions.SSLError as e:
-            logging.error(f'Erreur ssl {self.url}')
+            logging.error(f'Erreur ssl {cls.url}')
             logging.error(e)
             return None
         try:

--- a/indice_pollution/regions/Nouvelle-Aquitaine.py
+++ b/indice_pollution/regions/Nouvelle-Aquitaine.py
@@ -44,7 +44,8 @@ class Episode(Service, EpisodeMixin):
     def attributes_getter(self, feature):
         return feature['properties']
 
-    def getter(self, attributes):
+    @classmethod
+    def getter(cls, attributes):
         polluant_code_pol = {
             "O3": "7",
             "NO2": "8",
@@ -71,8 +72,8 @@ class Forecast(Service, ForecastMixin):
             'outputFormat': 'json',
         }
 
-    @property
-    def params_fetch_all(self):
+    @classmethod
+    def params_fetch_all(cls):
         filter_date_ech = f'<PropertyIsGreaterThanOrEqualTo><PropertyName>date_ech</PropertyName><Literal>{date.today()}T00:00:00Z</Literal></PropertyIsGreaterThanOrEqualTo>'
         return {
             'service': 'wfs',
@@ -82,7 +83,8 @@ class Forecast(Service, ForecastMixin):
             'outputFormat': 'json',
         }
 
-    def get_from_scraping(self, previous_results, date_, insee):
+    @classmethod
+    def get_from_scraping(cls, previous_results, date_, insee):
         url = f'https://www.atmo-nouvelleaquitaine.org/monair/commune/{insee}'
         try:
             r = requests.get(url)
@@ -101,7 +103,7 @@ class Forecast(Service, ForecastMixin):
         days = controls[0].find_all('a', class_='raster-control-link')
 
         return [
-            self.getter({
+            cls.getter({
                 "date": str(datetime.fromtimestamp(int(day.attrs.get('data-rasterid'))).date()),
                 "indice": int(day.attrs.get('data-index')) - 1,
             })

--- a/indice_pollution/regions/Occitanie.py
+++ b/indice_pollution/regions/Occitanie.py
@@ -27,8 +27,9 @@ class Forecast(Service, ForecastMixin):
             'outSR': '4326'
         }
 
-    def get_from_scraping(self, previous_results, date_, insee):
-        url = self.get_url(insee)
+    @classmethod
+    def get_from_scraping(cls, previous_results, date_, insee):
+        url = cls.get_url(insee)
         if not url:
             return []
         r = requests.get(url)
@@ -37,14 +38,15 @@ class Forecast(Service, ForecastMixin):
         j = json.loads(script.contents[0])
         city_iqa = j['atmo_mesures']['city_iqa']
         return [
-            self.getter({
+            cls.getter({
                 "indice": int(v['iqa']) - 1,
                 "date": str(parse(v['date']).date())
             })
             for v in city_iqa
         ]
 
-    def get_url(self, insee):
+    @classmethod
+    def get_url(cls, insee):
         r = requests.get(f'https://geo.api.gouv.fr/communes/{insee}',
                 params={
                     "fields": "codesPostaux",

--- a/indice_pollution/regions/Pays de la Loire.py
+++ b/indice_pollution/regions/Pays de la Loire.py
@@ -29,8 +29,8 @@ class Episode(Service, EpisodeMixin):
             "CQL_FILTER": f"date_ech >= {date_}T00:00:00Z AND code_zone='{commune.departement.code}'"
         }
 
-    @property
-    def params_fetch_all(self):
+    @classmethod
+    def params_fetch_all(cls):
         return {
             "version": "2.0.0",
             "typeName": "alrt3j_pays_de_la_loire:alrt3j_pays_de_la_loire",
@@ -53,8 +53,8 @@ class Forecast(Service, ForecastMixin):
             "export": "json"
         }
 
-    @property
-    def params_fetch_all(self):
+    @classmethod
+    def params_fetch_all(cls):
         return {
             "version": "2.0.0",
             "typeName": "ind_pays_de_la_loire:ind_pays_de_la_loire ",
@@ -64,13 +64,16 @@ class Forecast(Service, ForecastMixin):
             "CQL_FILTER": f"date_ech >= {date.today()}T00:00:00Z AND type_zone='EPCI'"
         }
 
-    def features(self, r):
+    @classmethod
+    def features(cls, r):
         return r.json().get('results', [])
 
-    def attributes_getter(self, feature):
+    @classmethod
+    def attributes_getter(cls, feature):
         return feature
 
-    def getter(self, feature):
+    @classmethod
+    def getter(cls, feature):
         return super().getter({
             "sous_indices": feature.get('sous_indice'),
             **feature

--- a/indice_pollution/regions/Sud.py
+++ b/indice_pollution/regions/Sud.py
@@ -26,13 +26,13 @@ class Episode(Service, EpisodeMixin):
             'geometryType': 'esriGeometryPoint',
         }
 
-    @property
-    def params_fetch_all(self):
+    @classmethod
+    def params_fetch_all(cls):
         date_ = date.today()
         tomorrow_date = date_ + timedelta(days=1)
 
-        fr_date = date_.strftime(self.fr_date_format)
-        fr_tomorrow = tomorrow_date.strftime(self.fr_date_format)
+        fr_date = date_.strftime(cls.fr_date_format)
+        fr_tomorrow = tomorrow_date.strftime(cls.fr_date_format)
 
         return {
             'service': 'WFS',
@@ -66,13 +66,13 @@ class Forecast(Service, ForecastMixin):
             'outputFormat': 'json'
         }
 
-    @property
-    def params_fetch_all(self):
+    @classmethod
+    def params_fetch_all(cls):
         date_ = date.today()
         tomorrow_date = date_ + timedelta(days=1)
 
-        fr_date = date_.strftime(self.fr_date_format)
-        fr_tomorrow = tomorrow_date.strftime(self.fr_date_format)
+        fr_date = date_.strftime(cls.fr_date_format)
+        fr_tomorrow = tomorrow_date.strftime(cls.fr_date_format)
 
         return {
             'service': 'WFS',

--- a/indice_pollution/regions/Île-de-France.py
+++ b/indice_pollution/regions/Île-de-France.py
@@ -31,8 +31,8 @@ class Forecast(Service, ForecastMixin):
             'CQL_FILTER': f"date_ech >= '{date_}T00:00:00Z' AND code_zone={insee}"
         }
 
-    @property
-    def params_fetch_all(self):
+    @classmethod
+    def params_fetch_all(cls):
         return {
             'service': 'WFS',
             'version': '2.0.0',
@@ -42,7 +42,8 @@ class Forecast(Service, ForecastMixin):
             'CQL_FILTER': f'(date_dif >= {date.today()}) OR (date_ech = {date.today()})'
         }
 
-    def get_from_scraping(self, previous_results, date_, insee):
+    @classmethod
+    def get_from_scraping(cls, previous_results, date_, insee):
         api_key = os.getenv('AIRPARIF_API_KEY')
         if not api_key:
             return []
@@ -55,7 +56,7 @@ class Forecast(Service, ForecastMixin):
         to_return = []
         for _k, indices in r.json().items():
             to_return = [
-                self.getter({
+                cls.getter({
                     "date": indice["date"],
                     "lib_qual": indice["indice"],
                 })
@@ -71,7 +72,8 @@ class Episode(Service, EpisodeMixin):
     fetch_only_from_scraping = True
     zone_type = 'region'
 
-    def get_from_scraping(self, to_return=[], date_=None, insee=None):
+    @classmethod
+    def get_from_scraping(cls, to_return=[], date_=None, insee=None):
         api_key = os.getenv('AIRPARIF_API_KEY')
         polluant_code_pol = {
             "O3": "7",


### PR DESCRIPTION
On a maintenant une tâche par appel à un `save_all`, ce qui permet de ne pas tout planter quand un des `save_all` plante