### PR TITLE
Changement de flux ATMO pour Bretagne car prévision jour J datée de la veille

### DIFF
--- a/indice_pollution/regions/Bretagne.py
+++ b/indice_pollution/regions/Bretagne.py
@@ -4,6 +4,7 @@ from . import EpisodeMixin, ForecastMixin
 from requests import adapters
 import ssl
 from urllib3 import poolmanager
+from datetime import date
 
 class TLSAdapter(adapters.HTTPAdapter):
 
@@ -221,12 +222,13 @@ class Forecast(Service, ForecastMixin):
             'CQL_FILTER': f"code_zone = {epci} AND date_ech>='{date_}'"
         }
 
-    params_fetch_all= {
+    params_fetch_all = {
         'service': 'WFS',
         'version': '1.0.0',
         'request': 'GetFeature',
-        'typeName': 'ind_bretagne:ind_bretagne_j1',
+        'typeName': f'ind_bretagne:ind_bretagne',
         'outputFormat': 'application/json',
+        'CQL_FILTER': f"date_ech>='{date.today()}'"
     }
 
 class Episode(Service, EpisodeMixin):


### PR DESCRIPTION
L'ancien flux utilisé était :
> Indice quotidien du jour J+1 de qualité de l’air pour les collectivités territoriales de Bretagne (pas de résultat si la prévision quotidienne n'est pas réalisée)

Le nouveau est :
> Indice quotidien de qualité de l’air pour les collectivités territoriales de Bretagne pour l’année civile en cours jusqu’au lendemain et l’année précédente complète (à partir du 01/01/2021)

Il est mis à jour sensiblement au même moment entre 10h et 11h au plus tôt.

⚠️ Les 2 sources sont sans polluants comme le site web https://www.airbreizh.asso.fr/epci/?epci=243500139