### PR TITLE
Changement de flux ATMO pour CVL car polluants absents

### DIFF
--- a/indice_pollution/regions/Centre-Val de Loire.py
+++ b/indice_pollution/regions/Centre-Val de Loire.py
@@ -64,12 +64,7 @@ class Forecast(Service, ForecastMixin):
         )
         return list(r.json().values())[0]
 
-    params_fetch_all = {
-        'where': "1=1",
-        'outFields': "*",
-        'f': 'json',
-        'outSR': '4326'
-    }
+    url_fetch_all = 'https://services1.arcgis.com/HzzPcgRsxxyIZdlU/ArcGIS/rest/services/Indices_Atmo_%C3%A0_la_commune/FeatureServer/0/query'
 
 class Episode(Service, EpisodeMixin):
     url = "https://services1.arcgis.com/HzzPcgRsxxyIZdlU/arcgis/rest/services/alerte_3j1/FeatureServer/0/query"


### PR DESCRIPTION
Le nouveau flux présent les polluants contrairement à l'ancien (J-1, J, J+1).

Par contre, il a le défaut d'avoir plus tard les prévisions du lendemain.